### PR TITLE
Passing interface to helper on Peripheral connect

### DIFF
--- a/bluepy/btle.py
+++ b/bluepy/btle.py
@@ -385,7 +385,7 @@ class Peripheral(BluepyHelper):
             raise ValueError("Expected MAC address, got %s" % repr(addr))
         if addrType not in (ADDR_TYPE_PUBLIC, ADDR_TYPE_RANDOM):
             raise ValueError("Expected address type public or random, got {}".format(addrType))
-        self._startHelper()
+        self._startHelper(iface)
         self.addr = addr
         self.addrType = addrType
         self.iface = iface


### PR DESCRIPTION
Interface was not being passed to `_startHelper()`, so `mgmt_setup()` could not be started unless using helper functions directly.